### PR TITLE
Lazy initiate javadocs & sources jar

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,10 +1,10 @@
 import org.ajoberstar.grgit.Grgit
-import net.minecrell.gradle.licenser.LicenseExtension
+import org.cadixdev.gradle.licenser.LicenseExtension
 
 plugins {
     id("java-library")
-    id("net.minecrell.licenser")
-    id("maven")
+    id("org.cadixdev.licenser") version "0.6.1"
+    id("maven-publish")
     id("eclipse")
     id("idea")
     id("com.jfrog.artifactory")
@@ -50,11 +50,16 @@ dependencies {
     "testImplementation"("org.junit.jupiter:junit-jupiter-api:${Versions.JUNIT}")
     "testImplementation"("org.junit.jupiter:junit-jupiter-params:${Versions.JUNIT}")
     "testImplementation"("org.hamcrest:hamcrest:2.2")
-    "testRuntime"("org.junit.jupiter:junit-jupiter-engine:${Versions.JUNIT}")
+    "testRuntimeOnly"("org.junit.jupiter:junit-jupiter-engine:${Versions.JUNIT}")
+}
+
+java {
+    withSourcesJar()
+    withJavadocJar()
 }
 
 configure<LicenseExtension> {
-    header = rootProject.file("HEADER.txt")
+    header.set(resources.text.fromFile(file("HEADER.txt")))
     include("**/*.java")
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.5.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
I was heading forward to update squirrel id from 0.1.0 today and noticed the javadoc and sources jar got lost over the years.