### PR TITLE
Remove lowercase conversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Note: We recommend shading or shadowing in SquirrelID for distribution, **reloca
     <dependency>
         <groupId>org.enginehub</groupId>
         <artifactId>squirrelid</artifactId>
-        <version>0.3.0</version>
+        <version>0.4.0</version>
         <scope>compile</scope>
         <type>jar</type>
     </dependency>
@@ -121,7 +121,7 @@ repositories {
 }
 
 dependencies {
-    compile 'org.enginehub:squirrelid:0.3.0'
+    compile 'org.enginehub:squirrelid:0.4.0'
 }
 ```
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 group=org.enginehub
-version=0.4.0-SNAPSHOT
+version=0.4.0

--- a/src/main/java/org/enginehub/squirrelid/resolver/CombinedProfileService.java
+++ b/src/main/java/org/enginehub/squirrelid/resolver/CombinedProfileService.java
@@ -89,14 +89,14 @@ public class CombinedProfileService implements ProfileService {
         List<Profile> totalResults = new ArrayList<>();
 
         for (String name : names) {
-            missing.add(name.toLowerCase(Locale.US));
+            missing.add(name);
         }
 
         for (ProfileService service : services) {
             ImmutableList<Profile> results = service.findAllByName(missing);
 
             for (Profile profile : results) {
-                String nameLower = profile.getName().toLowerCase(Locale.US);
+                String nameLower = profile.getName();
                 missing.remove(nameLower);
                 totalResults.add(profile);
             }
@@ -114,12 +114,12 @@ public class CombinedProfileService implements ProfileService {
         final List<String> missing = Collections.synchronizedList(new ArrayList<>());
 
         Predicate<Profile> forwardingConsumer = profile -> {
-            missing.remove(profile.getName().toLowerCase(Locale.US));
+            missing.remove(profile.getName());
             return consumer.test(profile);
         };
 
         for (String name : names) {
-            missing.add(name.toLowerCase(Locale.US));
+            missing.add(name);
         }
 
         for (ProfileService service : services) {

--- a/src/main/java/org/enginehub/squirrelid/resolver/HashMapService.java
+++ b/src/main/java/org/enginehub/squirrelid/resolver/HashMapService.java
@@ -51,8 +51,8 @@ public class HashMapService extends SingleRequestService {
      */
     public HashMapService(Map<String, UUID> map) {
         for (Map.Entry<String, UUID> entry : map.entrySet()) {
-            this.nameToIdMap.put(entry.getKey().toLowerCase(Locale.US), entry.getValue());
-            this.idToNameMap.put(entry.getValue(), entry.getKey().toLowerCase(Locale.US));
+            this.nameToIdMap.put(entry.getKey(), entry.getValue());
+            this.idToNameMap.put(entry.getValue(), entry.getKey());
         }
     }
 
@@ -62,8 +62,8 @@ public class HashMapService extends SingleRequestService {
      * @param profile the profile
      */
     public void put(Profile profile) {
-        this.nameToIdMap.put(profile.getName().toLowerCase(Locale.US), profile.getUniqueId());
-        this.idToNameMap.put(profile.getUniqueId(), profile.getName().toLowerCase(Locale.US));
+        this.nameToIdMap.put(profile.getName(), profile.getUniqueId());
+        this.idToNameMap.put(profile.getUniqueId(), profile.getName());
     }
 
     /**
@@ -85,7 +85,7 @@ public class HashMapService extends SingleRequestService {
     @Nullable
     @Override
     public Profile findByName(String name) throws IOException, InterruptedException {
-        UUID uuid = nameToIdMap.get(name.toLowerCase(Locale.US));
+        UUID uuid = nameToIdMap.get(name);
         if (uuid != null) {
             return new Profile(uuid, name);
         } else {


### PR DESCRIPTION
We shouldn't rely on fact that resolving UUID for lowercase version of username would result in resolving the real one, i.e. they must be considered different. This behavior is undocumented and recently isn't supported by Paper (see an [issue](https://github.com/PaperMC/Paper/issues/7700) and comments to [PR](https://github.com/PaperMC/Paper/pull/7723)).